### PR TITLE
Move the tag / feed file generation earlier in the posts hooks.

### DIFF
--- a/_plugins/tag_generator.rb
+++ b/_plugins/tag_generator.rb
@@ -1,4 +1,4 @@
-Jekyll::Hooks.register :posts, :post_write do |post|
+Jekyll::Hooks.register :posts, :pre_render do |post|
     all_existing_tags = Dir.entries("_tags")
       .map { |t| t.match(/(.*).md/) }
       .compact.map { |m| m[1] }


### PR DESCRIPTION
May resolve issue discussed in https://github.com/rcgsheffield/hpc-changelog/pull/16

~~**Will**~~ Should resolve problem with local build process needing to run twice to generate the tag / feed precursor files, then a second time to generate the static site files (but doesn't?)

May need to force the hook to do a full regenerate when new tags/feeds are detected / added.