### PR TITLE
Rename pre-emptable to preemptable

### DIFF
--- a/_posts/2022-02-09-bessemer-preemptable-jobs.md
+++ b/_posts/2022-02-09-bessemer-preemptable-jobs.md
@@ -1,9 +1,9 @@
 ---
-title:  "Bessemer Slurm config change: enabled pre-emptable jobs"
+title:  "Bessemer Slurm config change: enabled preemptable jobs"
 category: New
-tags: Bessemer Slurm pre-emptable
+tags: Bessemer Slurm preemptable
 ---
 
-Users can submit _pre-emptable_ jobs to make use of idle CPUs and/or GPUs in private nodes in Bessemer.  If the owners of those private nodes then submit jobs that require those resources to run then the pre-emptable jobs will be cancelled.
+Users can submit _preemptable_ jobs to make use of idle CPUs and/or GPUs in private nodes in Bessemer.  If the owners of those private nodes then submit jobs that require those resources to run then the preemptable jobs will be cancelled.
 
-More information: [https://docs.hpc.shef.ac.uk/en/latest/hpc/scheduler/index.html#pre-emptable-jobs](https://docs.hpc.shef.ac.uk/en/latest/hpc/scheduler/index.html#pre-emptable-jobs)
+More information: [https://docs.hpc.shef.ac.uk/en/latest/hpc/scheduler/index.html#preemptable-jobs](https://docs.hpc.shef.ac.uk/en/latest/hpc/scheduler/index.html#preemptable-jobs)

--- a/_tags/pre-emptable.md
+++ b/_tags/pre-emptable.md
@@ -1,4 +1,0 @@
----
-layout: tags
-tag-name: pre-emptable
----

--- a/_tags/preemptable.md
+++ b/_tags/preemptable.md
@@ -1,0 +1,4 @@
+---
+layout: tags
+tag-name: preemptable
+---

--- a/feeds/tags/pre-emptable.xml
+++ b/feeds/tags/pre-emptable.xml
@@ -1,4 +1,0 @@
----
-layout: feeds
-tag-name: pre-emptable
----

--- a/feeds/tags/preemptable.xml
+++ b/feeds/tags/preemptable.xml
@@ -1,0 +1,4 @@
+---
+layout: feeds
+tag-name: preemptable
+---


### PR DESCRIPTION
My spell checker tells me 'preemptable' is the correct; no hyphen needed.
