### PR TITLE
Patch the GHA site deploy action for new domain

### DIFF
--- a/.github/workflows/jekyll-build-deploy.yml
+++ b/.github/workflows/jekyll-build-deploy.yml
@@ -34,3 +34,4 @@ jobs:
           # GITHUB_TOKEN secret is set up automatically
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
+          cname: changelog.hpc.shef.ac.uk


### PR DESCRIPTION
aka https://changelog.hpc.shef.ac.uk/