### PR TITLE
JAGS added to Bessemer

### DIFF
--- a/_posts/2022-03-24-JAGS-bessemer-install.md
+++ b/_posts/2022-03-24-JAGS-bessemer-install.md
@@ -1,0 +1,9 @@
+---
+title:  "New software installed: JAGS 4.3.0"
+category: New
+tags: JAGS software bessemer
+---
+The software JAGS (Just Another Gibbs Sampler) has been installed on Bessemer.
+It is a program for analysis of Bayesian hierarchical models using Markov Chain Monte Carlo (MCMC) simulation not wholly unlike BUGS.
+
+The documentation for the usage of this software can now be found at: [https://docs.hpc.shef.ac.uk/en/latest/bessemer/software/apps/JAGS.html](https://docs.hpc.shef.ac.uk/en/latest/bessemer/software/apps/JAGS.html)

--- a/_tags/JAGS.md
+++ b/_tags/JAGS.md
@@ -1,0 +1,4 @@
+---
+layout: tags
+tag-name: JAGS
+---

--- a/feeds/tags/JAGS.xml
+++ b/feeds/tags/JAGS.xml
@@ -1,0 +1,4 @@
+---
+layout: feeds
+tag-name: JAGS
+---


### PR DESCRIPTION
First time JAGS is on Bessemer. Given Github actions is currently stuck I have guessed the JAGS URL path. (It's probably fine but check before merge.)